### PR TITLE
make directory lister trigger if mime type is httpd/unix-directory

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/images"
@@ -118,7 +120,7 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			writeJsonQuiet(w, r, http.StatusOK, entry)
 			return
 		}
-		if entry.Attr.Mime == "" {
+		if slices.Contains([]string{"httpd/unix-directory", ""}, entry.Attr.Mime) {
 			fs.listDirectoryHandler(w, r)
 			return
 		}


### PR DESCRIPTION
# What problem are we solving?

when folders are created via the s3 gateway, the mime type `httpd/unix-directory` is attached to the folder. https://github.com/seaweedfs/seaweedfs/blob/master/weed/s3api/s3api_object_handlers.go#L102

however, when listing files via the filer server, the filer checks if the mime type is empty to determine whether or not to display the folder listing. https://github.com/seaweedfs/seaweedfs/blob/master/weed/server/filer_server_handlers_read.go#L121

# How are we solving the problem?

have filer server check if the mime type is either `httpd/unix-directory` or empty, instead of just empty, which will make it properly show directory listing on directories uploaded with s3
